### PR TITLE
Meteor 3.0 compatibility

### DIFF
--- a/package.js
+++ b/package.js
@@ -5,8 +5,8 @@ Package.describe({
   git: 'https://github.com/iron-meteor/iron-layout'
 });
 
-Package.on_use(function (api) {
-  api.versionsFrom('METEOR@0.9.2');
+Package.onUse(function (api) {
+  api.versionsFrom('3.0.2');
 
   // so our default_layout gets compiled
   api.use('templating');
@@ -29,13 +29,13 @@ Package.on_use(function (api) {
   api.use('cmather:blaze-layout@0.2.5', {weak: true});
   api.use('cmather:iron-layout@0.2.0', {weak: true});
 
-  api.add_files('version_conflict_errors.js');
-  api.add_files('default_layout.html');
-  api.add_files('layout.js');
+  api.addFiles('version_conflict_errors.js');
+  api.addFiles('default_layout.html');
+  api.addFiles('layout.js');
 });
 
 Package.on_test(function (api) {
-  api.versionsFrom('METEOR@0.9.2');
+  api.versionsFrom('3.0.2');
 
   api.use('iron:layout');
   api.use('tinytest');
@@ -43,6 +43,6 @@ Package.on_test(function (api) {
   api.use('templating');
   api.use('deps');
 
-  api.add_files('layout_test.html', 'client');
-  api.add_files('layout_test.js', 'client');
+  api.addFiles('layout_test.html', 'client');
+  api.addFiles('layout_test.js', 'client');
 });

--- a/package.js
+++ b/package.js
@@ -34,7 +34,7 @@ Package.onUse(function (api) {
   api.addFiles('layout.js');
 });
 
-Package.on_test(function (api) {
+Package.onTest(function (api) {
   api.versionsFrom('3.0.2');
 
   api.use('iron:layout');


### PR DESCRIPTION
Adapting iron-router to run in Meteor 3
Major changes :
- meteor api 3.0.2
Minor changes
- package methods latest style (onUse, onTest, addFiles)